### PR TITLE
Update Linux-Build-Instructions.md

### DIFF
--- a/Getting-Started/Installing/Linux-Build-Instructions.md
+++ b/Getting-Started/Installing/Linux-Build-Instructions.md
@@ -2,8 +2,8 @@
 
 **Note:** These instructions have been created by building OSVR-Core on a bare bones Ubuntu 14.04. The same steps would work on other Linux distributions as well.
 
-### Compiler: Clang or GCC or G++
-Either one of those should work. You will need to build jsoncpp and libfunctionality separately from OSVR-Core : see <http://wiki.osvr.com/doku.php?id=startingcore>
+### Compiler: Clang or GCC/G++
+Either one of those should work. You will need to build libfunctionality separately from OSVR-Core.
 
 ### Required tools/libraries:
 Unless specified otherwise, you can use the package manager to get the tools mentioned below
@@ -12,7 +12,7 @@ Unless specified otherwise, you can use the package manager to get the tools men
 - CMake (3.0 or newer). Package manager had a version 2.x, so you should get the latest version from <http://CMake.org> or from PPA
 - OpenCV - `libopencv-dev`
 - Boost libraries (1.44 or newer) You don't need all of them but you'll need at least : `libboost1.xx-dev, libboost-thread1.xx-dev (includes required system, date-time and chrono), libboost-program-options1.xx-dev, libboost-filesystem1.xx-dev`) 
-	- There is a [bug in Boost 1.58.0](http://lists.boost.org/Archives/boost/2015/05/221933.php) which makes it incompatible. 
+	- A [bug in Boost 1.58.0](http://lists.boost.org/Archives/boost/2015/05/221933.php) was previously thought to make it incompatible, but nobody's had any issues with it recently, so we might no longer be triggering the (build) error condition anymore.
 - libusb1 - `libusb-1.0-0-dev`
 
 **CMake notes:** If you are new to CMake then read the following guidelines that you should follow to build OSVR-Core and other libraries, otherwise you can skip this section. To build a project with CMake you need to create a build directory inside your project main directory such as OSVR-Core/build. Next from the build directory, run the following CMake command:
@@ -29,7 +29,7 @@ Once you have the tools above, you can build the following libraries before you 
 
 `git clone --recursive https://github.com/OSVR/libfunctionality.git`
 
-- jsoncpp library. (You need to run CMake with flags below)  
+- jsoncpp library, if your distribution doesn't include it. If your distribution *does* include it, the package it has is probably fine, OSVR isn't too picky. If you do end up building jsoncpp, you'll want to run CMake with flags below for simplest use.
 
 `git clone --recursive https://github.com/VRPN/jsoncpp`
 
@@ -49,17 +49,12 @@ Finally just `make`, and watch it build (or grab a soda and read through more [O
 
 ### Known issues *(temporary)*
 
-If you do not get the `Added device: com_osvr_Multiserver/OSVRHackerDevKit0` when running `osvr-server` this means that you need to update VRPN with an updated HIDAPI version (See [issue #338] for more information). To do so, checkout and build the branch [non-windows-workaround] in your source directory:
-```
-git fetch origin non-windows-workaround
-git checkout non-windows-workaround
-git submodule update
-make -j4
-```
-If you are using one of the [HDK headsets], you will also need to run `osvr-server` as root, or you can install the following udev rules (See [issue #330] for more information): https://gist.github.com/rpavlik/98d21e14a7e6eeb52e95
+If you do not get the `Added device: com_osvr_Multiserver/OSVRHackerDevKit0` when running `osvr-server` and you're using an HDK:
+
+- Make sure you're building with the latest `master` branch of the source (and that, if you've updated the source recently, that you've done a `git submodule update --recursive` to update the submodules too), since the earlier HIDAPI bug requiring the `non-windows-workaround` branch has been fixed.
+- If you are using one of the [HDK headsets], you will also need to run `osvr-server` as root, or you can install the following udev rules (See [issue #330] for more information): https://gist.github.com/rpavlik/98d21e14a7e6eeb52e95
 
 [OSVR tutorials]:http://osvr.github.io/build-with/
 [issue #338]:https://github.com/OSVR/OSVR-Core/issues/338
-[non-windows-workaround]:https://github.com/OSVR/OSVR-Core/tree/non-windows-workaround
 [HDK headsets]:http://www.razerzone.com/osvr-hacker-dev-kit
 [issue #330]:https://github.com/OSVR/OSVR-Core/issues/330


### PR DESCRIPTION
Update build instructions, noting the fix of the HIDAPI issues.
Also update that Boost 1.58 isn't evil and that you can probably just use the jsoncpp from your distro.
