### PR TITLE
New page for updating HDK firmware from Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ if no parameter is specified, a default file is used.
 - [TrackerViewer](https://github.com/OSVR/OSVR-Tracker-Viewer#readme)
   - [Additional Tracker Viewer documentation](http://osvr.github.io/doc/tracker-viewer/)
 - [OSVR Control](Utilities/OSVRControl.md)
+- [Updating HDK Firmware from Linux](Utilities/UpdateHDKLinux.md)
 - [Distortionizer](https://github.com/OSVR/distortionizer#readme) helps measure distortion parameters for HMDs
 - [Latency tester](https://github.com/sensics/Latency-Test). Open-source Arduino-based latency tester
 - [OSVR HDK Video Status Tool](https://github.com/sensics/OSVR-HDK-Video-Status#readme) - Find out what video signal the HDK is receiving.

--- a/Utilities/UpdateHDKLinux.md
+++ b/Utilities/UpdateHDKLinux.md
@@ -1,0 +1,83 @@
+# Updating the HDK firmware from Linux
+
+This will describe the process to update the HDK firmware from CLI in Linux. This guide expects a certain familiarity with Linux and comfort with CLI usage.
+
+**Note: This process has some risk associated with it. If instructions are not entered properly it may result in bricking the device.**
+
+## Requirements
+
+- [dfu-programmer](https://dfu-programmer.github.io/)
+  - [AUR package](https://aur.archlinux.org/packages/dfu-programmer/) - For Arch Linux users
+- [screen](https://www.gnu.org/software/screen/) - Included in many base installs
+- sha1sum - Included in many base installs
+
+## Checking the current firmware version
+
+Use `screen` to connect to the HDK device
+
+**Note: Remember to run this with root privileges(sudo or root shell).**
+```bash
+screen /dev/ttyACM0
+```
+
+Once connected you should have a blank screen with the terminal cursor flashing in the upper left corner.
+
+Enter the following exactly and press enter to execute(the '#' symbol is NOT a prompt):
+```
+#?v
+```
+To exit the screen session:
+
+1. Press `ctrl+a`
+2. Then `shift+k`
+3. It will prompt for y/n to quit, select 'y'
+
+## Download and Verify the new firmware (HDK1.3 only)
+
+The latest firmware for the HDK1.3:
+```bash
+Link: https://drive.google.com/file/d/0B1QNig02lQa8LXZOZlYtYnY4djg/view?usp=sharing
+SHA1 checksum: 3d7f8ac7412fb9f8c11ae082c4c27e550dad8012
+```
+**Note: Do not use a file if the checksum does not match.**
+
+Verify the checksum of the file (replace firmware.hex with the name of the file you downloaded):
+```bash
+sha1sum firmware.hex
+3d7f8ac7412fb9f8c11ae082c4c27e550dad8012 firmware.hex
+```
+
+## Updating Firmware (Currently only verified for HDK1.3)
+
+**Note: All commands in this section require root privileges.**
+
+I recommend you watch `dmesg` or use `journalctl -f` in a separate terminal to see activity  of the device attaching and changing state.
+
+### Put the HDK MCU into bootloader mode (HDK1.3 only)
+
+Use `screen` to connect to the HDK
+```bash
+screen /dev/ttyACM0
+```
+
+Enter the following exactly and press enter to execute:
+```
+#?B1948
+```
+**Note: The screen session should exit, this is expected as the device is rebooting into bootloader mode.**
+
+### Uploading the new firmware (HDK1.3 only)
+
+With the HDK MCU in bootloader mode (After the usb activity in the logs stops) the new firmware can be uploaded.
+
+Use the `dfu-programmer` utility to upload the new firmware (replace 'firmware.hex' with the name of the file that was downloaded earlier):
+```bash
+dfu-programmer atxmega256a3bu flash --force --suppress-bootloader-mem firmware.hex
+```
+
+Reboot the HDK MCU to normal operation using the new firmware:
+```bash
+dfu-programmer atxmega256a3bu launch
+```
+**Note: The device should again disconnect and reconnect.  The device is ready to use once the logs stop.**
+


### PR DESCRIPTION
Adds a new page under Utilities for updating the HDK firmware from Linux.

This page specifically covers the HDK1.3 as that is the device I own and can't verify any other device's instructions.

I linked this in the README.md page; I wasn't sure of a better place for it.
