### PR TITLE
Update choco commands

### DIFF
--- a/Developing/Windows-Build-Environment.md
+++ b/Developing/Windows-Build-Environment.md
@@ -19,7 +19,7 @@ choco pin add -name OpenCV
 
 and, depending on if you want to build 32-bit or 64-bit, add one or both of the following packages: `boost-x86-msvc2013` (32-bit), `boost-x64-msvc2013` (64-bit).  i.e. :
 ```cmd
-choco install -s osvr-deps -y boostx64-msvc2013
+choco install -s osvr-deps -y boost-x64-msvc2013
 ```
 On your own, you'll want to make sure you have Git, a proper notepad replacement like notepad++ or notepad2mod, etc.
 

--- a/Developing/Windows-Build-Environment.md
+++ b/Developing/Windows-Build-Environment.md
@@ -12,13 +12,15 @@ You can use [Chocolatey][] (aka "choco") to install the dependencies/packages re
 
 ```cmd
 choco source add --name="osvr-deps" -s="https://www.myget.org/F/osvr-deps/"
-choco install -y cmake
-choco install -y OpenCV -version 2.4.10.20150209
+choco install -s osvr-deps -y cmake
+choco install -s osvr-deps -y OpenCV
 choco pin add -name OpenCV
 ```
 
-and, depending on if you want to build 32-bit or 64-bit, add one or both of the following package names to that last install line or a new one: `boost-x86-msvc2013` (32-bit), `boost-x64-msvc2013` (64-bit)
-
+and, depending on if you want to build 32-bit or 64-bit, add one or both of the following packages: `boost-x86-msvc2013` (32-bit), `boost-x64-msvc2013` (64-bit).  i.e. :
+```cmd
+choco install -s osvr-deps -y boostx64-msvc2013
+```
 On your own, you'll want to make sure you have Git, a proper notepad replacement like notepad++ or notepad2mod, etc.
 
 ## Alternate build environment: MSYS2/MinGW64


### PR DESCRIPTION
The current OpenCV command errors out due to wrong version available for OpenCV so spropose the specifying of the added osvr-deps repo to commands to make sure libraries/packages versions get pulled from osvr-deps if they can and doing so without having to specify version.