### PR TITLE
Added Guides Page for setting up development environments

### DIFF
--- a/Developing/Guides.md
+++ b/Developing/Guides.md
@@ -13,7 +13,7 @@ The [osvr-core-ubuntu-build-script](https://bitbucket.org/monkygames/osvr-core-u
 ## Windows
 
 ### Experienced Users
-The [Windows Build Environment](Developing/Windows-Build-Environment.md) contains documentation for experencied programers/users to setup a development environment on the windows platform.
+The [Windows Build Environment](Windows-Build-Environment.md) contains documentation for experencied programers/users to setup a development environment on the windows platform.
 
 ### Novice Users
 The [STEAMVR-OSVR compilation for noobs](https://github.com/OSVR/SteamVR-OSVR/files/1117930/STEAMVR-OSVR.compilation.for.noobs.pdf) is a guide for novice users to setup and compile OSVR.

--- a/Developing/Guides.md
+++ b/Developing/Guides.md
@@ -1,0 +1,19 @@
+# Guides
+
+This document contains a list of guides for setting up a development environment for the specified platform.
+
+## Linux
+
+### Arch Linux
+The following [wiki](https://wiki.archlinux.org/index.php/Virtual_reality#OSVR) has instructions for using AUR repos for setting up the environment
+
+### Ubuntu 
+The [osvr-core-ubuntu-build-script](https://bitbucket.org/monkygames/osvr-core-ubuntu-build-script) is a script that sets up a development enviroment on the host or can provision a virtual machine via vagrant to setup a development environment.
+
+## Windows
+
+### Experienced Users
+The [Windows Build Environment](Developing/Windows-Build-Environment.md) contains documentation for experencied programers/users to setup a development environment on the windows platform.
+
+### Novice Users
+The [STEAMVR-OSVR compilation for noobs](https://github.com/OSVR/SteamVR-OSVR/files/1117930/STEAMVR-OSVR.compilation.for.noobs.pdf) is a guide for novice users to setup and compile OSVR.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ if no parameter is specified, a default file is used.
 - [Re-flash bootloader on OSVR HDK](Configuring/HDKBootloader.md)
 
 # Developing with OSVR
-- Setting up the development environment
-  - [Windows](Developing/Windows-Build-Environment.md)
+- Setting up a development environment
+  - [Guides](Developing/Guides.md)
 - [Directory of projects](http://osvr.github.io/contributing/)
 - [Doxygen-generated developer documentation of OSVR-Core](http://resource.osvr.com/docs/OSVR-Core/)
 - [Doxygen-generated internal documentation of OSVR-Core](http://resource.osvr.com/internal-docs/OSVR-Core-Implementation/)


### PR DESCRIPTION
There have been 3 community members who have created documentation on how to setup development environments for OSVR.  I thought it would be good to capture this documentation in the wiki.  So I created a separate page for the guides which includes the existing windows documentation.